### PR TITLE
Bugfix/#21003 add checks in hosts file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+# Ruby
 Gemfile.lock

--- a/spec/configuration/hosts_spec.rb
+++ b/spec/configuration/hosts_spec.rb
@@ -33,3 +33,32 @@ describe 'Self awareness of the hostname' do
     its(:content) { should match(/#{remote_ip_regex}\s+#{hostname}\.node\s*/) }
   end
 end
+
+describe 'Services defined in the registered manager' do
+  describe file('/etc/hosts') do
+    before do
+      skip 'Cdomain not defined in /etc/redborder/cdomain' unless file('/etc/redborder/cdomain').exists?
+    end
+    it 'Checks DNS resolution from right domain' do
+      hosts_content = subject.content
+      # Find first no localhost line
+      line = hosts_content.lines.find do |l|
+        l_ip = l.split.first
+        l_ip && !['127.0.0.1', '::1'].include?(l_ip) && !l.strip.start_with?('#')
+      end
+      skip 'No line with a dynamic IP found. Maybe the IPS is not registered yet.' unless line
+
+      cdomain = file('/etc/redborder/cdomain').content.strip
+
+      [
+        "http2k.service.#{cdomain}",
+        "erchef.service.#{cdomain}",
+        "s3.service.#{cdomain}",
+        "f2k.service.#{cdomain}",
+        "kafka.service.#{cdomain}"
+      ].each do |name|
+        expect(line).to include(name)
+      end
+    end
+  end
+end

--- a/spec/configuration/hosts_spec.rb
+++ b/spec/configuration/hosts_spec.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Check for duplicate IPs in /etc/hosts' do
+  describe command("awk '{print $1}' /etc/hosts | sort | uniq -d | wc -l") do
+    its(:stdout) { should match(/^0$/) }
+  end
+end
+
+describe 'Default values of /etc/hosts' do
+  describe file('/etc/hosts') do
+    it { should exist }
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+
+    # Self conscience of localhost
+    its(:content) { should match(/127.0.0.1\s+localhost/) }
+    its(:content) { should match(/::1\s+localhost/) }
+  end
+end
+
+hostname = `hostname`.strip
+describe 'Self awareness of the hostname' do
+  describe file('/etc/hosts') do
+    # Check hostname entry
+    its(:content) { should match(/^127\.0\.0\.1\s+#{hostname}\s+/) }
+  end
+end
+
+# TODO: Check manager-node info is present in /etc/hosts after registration

--- a/spec/configuration/hosts_spec.rb
+++ b/spec/configuration/hosts_spec.rb
@@ -51,11 +51,11 @@ describe 'Services defined in the registered manager' do
       cdomain = file('/etc/redborder/cdomain').content.strip
 
       [
-        "http2k.service.#{cdomain}",
-        "erchef.service.#{cdomain}",
-        "s3.service.#{cdomain}",
-        "f2k.service.#{cdomain}",
-        "kafka.service.#{cdomain}"
+        "http2k.#{cdomain}",
+        "erchef.#{cdomain}",
+        "s3.#{cdomain}",
+        "f2k.#{cdomain}",
+        "kafka.#{cdomain}"
       ].each do |name|
         expect(line).to include(name)
       end

--- a/spec/configuration/hosts_spec.rb
+++ b/spec/configuration/hosts_spec.rb
@@ -23,15 +23,13 @@ describe 'Default values of /etc/hosts' do
   end
 end
 
-# THIS TEST ONLY PASSES IF REGISTERED
 describe 'Self awareness of the hostname' do
   hostname = command('hostname').stdout.strip
   describe file('/etc/hosts') do
-  # Check hostname entry
-    # its(:content) { should match(/^127\.0\.0\.1\s+#{hostname}\s+/) }
     before do
       skip('Node is not registered yet, skipping...') unless hostname != 'localhost'
     end
-    its(:content) { should match(/^(?!127\.0\.0\.1)(?!::1).*\s+#{hostname}\.node\s*/) }
+    remote_ip_regex = /^(?!127\.0\.0\.1)(?!::1).*/
+    its(:content) { should match(/#{remote_ip_regex}\s+#{hostname}\.node\s*/) }
   end
 end

--- a/spec/configuration/hosts_spec.rb
+++ b/spec/configuration/hosts_spec.rb
@@ -23,12 +23,15 @@ describe 'Default values of /etc/hosts' do
   end
 end
 
-hostname = `hostname`.strip
+# THIS TEST ONLY PASSES IF REGISTERED
 describe 'Self awareness of the hostname' do
+  hostname = command('hostname').stdout.strip
   describe file('/etc/hosts') do
-    # Check hostname entry
-    its(:content) { should match(/^127\.0\.0\.1\s+#{hostname}\s+/) }
+  # Check hostname entry
+    # its(:content) { should match(/^127\.0\.0\.1\s+#{hostname}\s+/) }
+    before do
+      skip('Node is not registered yet, skipping...') unless hostname != 'localhost'
+    end
+    its(:content) { should match(/^(?!127\.0\.0\.1)(?!::1).*\s+#{hostname}\.node\s*/) }
   end
 end
-
-# TODO: Check manager-node info is present in /etc/hosts after registration

--- a/spec/services/chef_spec.rb
+++ b/spec/services/chef_spec.rb
@@ -32,3 +32,15 @@ describe "Checking service_status service for #{service}..." do
     it { should be_file }
   end
 end
+
+describe 'Checking if should be registered to chef' do
+  hostname = command('hostname').stdout.strip
+  describe file('/etc/hosts') do
+    before do
+      skip('Node is not registered yet, skipping...') unless hostname != 'localhost'
+    end
+    remote_ip_regex = /^(?!127\.0\.0\.1)(?!::1).*/
+    its(:content) { should match(/#{remote_ip_regex}\s+erchef\.service\s*/) }
+    its(:content) { should match(/#{remote_ip_regex}\s+erchef\.redborder\.cluster\s*/) }
+  end
+end

--- a/spec/services/chef_spec.rb
+++ b/spec/services/chef_spec.rb
@@ -41,6 +41,6 @@ describe 'Checking if should be registered to chef' do
     end
     remote_ip_regex = /^(?!127\.0\.0\.1)(?!::1).*/
     its(:content) { should match(/#{remote_ip_regex}\s+erchef\.service\s*/) }
-    its(:content) { should match(/#{remote_ip_regex}\s+erchef\.redborder\.cluster\s*/) }
+    its(:content) { should match(/#{remote_ip_regex}\s+erchef\.service\.redborder\.cluster\s*/) }
   end
 end

--- a/spec/services/s3_spec.rb
+++ b/spec/services/s3_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+set :os, family: 'redhat', release: '9', arch: 'x86_64'
+
+describe 'Checking if should be registered to s3 in the manager' do
+  hostname = command('hostname').stdout.strip
+  describe file('/etc/hosts') do
+    before do
+      skip('Node is not registered yet, skipping...') unless hostname != 'localhost'
+    end
+    remote_ip_regex = /^(?!127\.0\.0\.1)(?!::1).*/
+    its(:content) { should match(/#{remote_ip_regex}\s+s3.service\s*/) }
+  end
+end


### PR DESCRIPTION
I added 3 checks:
1. etc/hosts is mandatory to have it and localhost should have basic services in IPS.
2. the IPS need access to chef and s3 services allocated in the manager during the whole time is registered against its manager.